### PR TITLE
Include font file in the build executable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,7 +1441,7 @@ dependencies = [
 
 [[package]]
 name = "snake_game"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "piston",
  "piston2d-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snake_game"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/game.rs
+++ b/src/game.rs
@@ -4,6 +4,7 @@ use graphics::glyph_cache::rusttype::GlyphCache;
 use graphics::Transformed;
 use opengl_graphics::{GlGraphics, TextureSettings};
 use piston::input::{Button, Key, RenderArgs};
+
 pub struct Game {
     pub gl: GlGraphics,
     pub snake: Snake,
@@ -27,8 +28,10 @@ impl Game {
 
     pub fn render_score(&mut self, args: &RenderArgs) {
         const WHITE: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
+        let font_bytes = include_bytes!("../assets/FiraSans-Regular.ttf"); // your file bytes
+
         let mut glyph_cache =
-            GlyphCache::new("assets/FiraSans-Regular.ttf", (), TextureSettings::new()).unwrap();
+            GlyphCache::from_bytes(font_bytes, (), TextureSettings::new()).unwrap();
         self.gl.draw(args.viewport(), |c, g| {
             graphics::Text::new_color(WHITE, 24)
                 .draw(


### PR DESCRIPTION
### Fix for font file failure

Fix: Include font file as binary in build executable

fixes #4